### PR TITLE
Drop the scipy minimum requirement to 1.10

### DIFF
--- a/conda-requirements.txt
+++ b/conda-requirements.txt
@@ -14,7 +14,7 @@ pywwt>=0.23
 pytz>=2024
 reproject>=0.13
 requests>=2
-scipy>=1.12
+scipy>=1.10
 shapely
 toasty
 wwt_api_client

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setup_args = dict(
         "pywwt>=0.23",
         "reproject>=0.13",
         "requests>=2",
-        "scipy>=1.12",
+        "scipy>=1.10",
     ],
     extras_require={
         "docs": [


### PR DESCRIPTION
The previous minimum was chosen just because it's what seems to be out now. But, it's preventing me from pip-installing daschlab on the SciServer astronomy image. So let's fix that!